### PR TITLE
Fix mocha theme installing incorrectly

### DIFF
--- a/plugin.toml
+++ b/plugin.toml
@@ -4,4 +4,4 @@ description = "The Catppuccin Theme"
 version = "0.1.2"
 author = "ghishadow"
 repository = "ghishadow/lapce-catppuccin"
-themes = ["catppuccin-latte.toml", "catppuccin-frappe.toml", "catppuccin-macchiato.toml", "catppuccin-mocha.toml "]
+themes = ["catppuccin-latte.toml", "catppuccin-frappe.toml", "catppuccin-macchiato.toml", "catppuccin-mocha.toml"]


### PR DESCRIPTION
the file for mocha would download with a single extra space in it's filename and would not show up in the theme selection